### PR TITLE
Calagator executable updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ pkg/
 spec/dummy
 .sass-cache
 .DS_Store
+.idea/

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem "turbolinks"
 # can't declare platform specific development dependencies in the gemspec.
 gem "byebug", platform: "mri"
 
+#development
+gem "sunspot_solr"
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing

--- a/bin/calagator
+++ b/bin/calagator
@@ -26,7 +26,9 @@ calagator install: install Calagator into an existing Rails application
       none
 END
 
-TEMPLATE = File.expand_path("../../rails_template.rb", __FILE__)
+__DIR__ = File.dirname(__FILE__)
+TEMPLATE = File.expand_path(File.join(__DIR__, "..", "rails_template.rb"))
+puts TEMPLATE
 
 command = ARGV.shift
 

--- a/bin/calagator
+++ b/bin/calagator
@@ -1,20 +1,6 @@
 #!/usr/bin/env ruby
 
-TEMPLATE = File.expand_path("../../rails_template.rb", __FILE__)
-
-command = ARGV.shift
-
-case command
-when /_\d+\.\d+\.\d+_/, 'new'
-  system "rails #{command} #{ARGV.join(' ')} -m #{TEMPLATE} --skip-bundle"
-when 'install'
-  system "bundle exec rake rails:template LOCATION=#{TEMPLATE}"
-else
-  puts DATA.read
-end
-
-__END__
-
+help_text =<<END
 calagator: setup Calagator in a new or existing Rails applicaton
 
 Usage:
@@ -27,7 +13,7 @@ calagator new: generates a new Rails app and install Calagator into it
     --dummy   # Generates an app suitable for use in spec/dummy for Calagator
               # development and testing
 
-    In the case of `calagator new`, all other options will be passed along 
+    In the case of `calagator new`, all other options will be passed along
     to `rails new`; see `rails new --help` for supported options.
 
     To generate an app using a specific Rails version, e.g. for 4.2.1:
@@ -38,4 +24,22 @@ calagator install: install Calagator into an existing Rails application
 
     Options:
       none
+END
+
+TEMPLATE = File.expand_path("../../rails_template.rb", __FILE__)
+
+command = ARGV.shift
+
+case command
+when /_\d+\.\d+\.\d+_/, 'new'
+  system "rails #{command} #{ARGV.join(' ')} -m #{TEMPLATE} --skip-bundle"
+when 'install'
+  system "bundle exec rake rails:template LOCATION=#{TEMPLATE}"
+else
+  puts help_text
+end
+
+__END__
+
+
 

--- a/calagator.gemspec
+++ b/calagator.gemspec
@@ -63,4 +63,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "simplecov", "~> 0.10.0"
   s.add_development_dependency "appraisal", "~> 2.0"
   s.add_development_dependency "gem-release", "~> 0.7"
+
+  #executables
+  s.executables << 'calagator'
 end

--- a/calagator.gemspec
+++ b/calagator.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ['>= 2.0.0', '< 2.2.0']
 
-  s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE.txt", "Rakefile", "README.md"]
+  s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE.txt", "Rakefile", "README.md", "rails_template.rb"]
   s.test_files = Dir["spec/**/*"]
 
   # When changing this Rails requirement, also update RAILS_REQUIREMENT in rails_template.rb

--- a/rails_template.rb
+++ b/rails_template.rb
@@ -23,9 +23,15 @@ if options[:database] == "postgresql" && ARGV.any? { |arg| arg =~ /--postgres-us
   end
 end
 
+
 if yes?("Is this for development on the Calagator gem? [yes/no]")
-  gpath = ask("Please enter the local path to the gem:")
-  gem "calagator", (generating_dummy && { path: relative_calagator_path.to_s }), path: gpath
+  gpath = ask("Please enter the local path to the gem (defaults to remote gem if path does not exist):")
+  if Dir.exists?(gpath)
+    gem "calagator", (generating_dummy && { path: relative_calagator_path.to_s }), path: gpath
+  else
+    puts "Not a valid path, installing remote gem"
+    gem "calagator", (generating_dummy && { path: relative_calagator_path.to_s })
+  end
 else
   gem "calagator", (generating_dummy && { path: relative_calagator_path.to_s })
 end

--- a/rails_template.rb
+++ b/rails_template.rb
@@ -23,7 +23,14 @@ if options[:database] == "postgresql" && ARGV.any? { |arg| arg =~ /--postgres-us
   end
 end
 
-gem "calagator", (generating_dummy && { path: relative_calagator_path.to_s })
+if yes?("Is this for development on the Calagator gem? [yes/no]")
+  gpath = ask("Please enter the local path to the gem:")
+  gem "calagator", (generating_dummy && { path: relative_calagator_path.to_s }), path: gpath
+else
+  gem "calagator", (generating_dummy && { path: relative_calagator_path.to_s })
+end
+
+# gem "calagator", (generating_dummy && { path: relative_calagator_path.to_s })
 run "bundle install"
 rake "db:create"
 generate "calagator:install", (generating_dummy && "--dummy")


### PR DESCRIPTION
- Add sunspot-solr as dev dependency, so that the user doesn't have to manually install solr for development
- Fix calagator executable new action so that the install instructions align with the behavior
- Help text now rendering in executable
- Prompt users with the option to add local gem path to the gem file if installing for development purposes, defaults to existing remote gem if path is invalid
- Resolves #440
